### PR TITLE
support Julia v0.7 and v1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,9 @@
-language: cpp
-compiler:
-  - clang
+language: julia
+os:
+  - linux
+julia:
+  - 0.7
+  - 1.0
+  - nightly
 notifications:
   email: false
-env:
-  matrix:
-    - JULIAVERSION="julianightlies"
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-script:
-  - julia -e 'Pkg.init(); Pkg.clone(pwd());Pkg.resolve(); Pkg.add("BinDeps"); Pkg.build("JellyFish"); Pkg.test("JellyFish")'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-BinDeps
+julia 0.7

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,2 +1,3 @@
-cd(Pkg.dir("JellyFish", "deps"))
-run(`make`)
+cd(@__DIR__) do
+    run(`make`)
+end

--- a/src/JellyFish.jl
+++ b/src/JellyFish.jl
@@ -1,11 +1,13 @@
 module JellyFish
+	using Libdl: find_library
+
 	export jaro_winkler, jaro_distance, hamming_distance, 
 		levenshtein_distance, damerau_levenshtein_distance, soundex, metaphone, 
 		match_rating_codex, match_rating_comparison, nysiis
-	const _jellyfishlib = find_library(["jellyfish"], [Pkg.dir("JellyFish", "deps")])
+	const _jellyfishlib = find_library(["jellyfish"], [joinpath(@__DIR__, "..", "deps")])
 
-	function _calls1s2type(func::Symbol, returntype::DataType, s1::String, s2::String)
-		ccall((func, _jellyfishlib), returntype, (Ptr{Cchar}, Ptr{Cchar}), s1, s2)
+	macro _calls1s2type(func, returntype, s1, s2)
+		:(ccall(($(esc(func)), _jellyfishlib), $(esc(returntype)), (Ptr{Cchar}, Ptr{Cchar}), $(esc(s1)), $(esc(s2))))
 	end
 
 	function jaro_winkler(s1::String, s2::String)
@@ -13,52 +15,52 @@ module JellyFish
 	end
 
 	function jaro_distance(s1::String, s2::String)
-		_calls1s2type(:jaro_distance, Cdouble, s1, s2)
+		@_calls1s2type(:jaro_distance, Cdouble, s1, s2)
 	end
 
 	function hamming_distance(s1::String, s2::String)
-		int(_calls1s2type(:hamming_distance, Csize_t, s1, s2))
+		convert(Int, @_calls1s2type(:hamming_distance, Csize_t, s1, s2))
 	end
 
 	function levenshtein_distance(s1::String, s2::String)
-		_calls1s2type(:levenshtein_distance, Cint, s1, s2)
+		@_calls1s2type(:levenshtein_distance, Cint, s1, s2)
 	end
 
 	function damerau_levenshtein_distance(s1::String, s2::String)
-		_calls1s2type(:damerau_levenshtein_distance, Cint, s1, s2)
+		@_calls1s2type(:damerau_levenshtein_distance, Cint, s1, s2)
 	end
 
 	# for some reason doesn't work:
 	function _callstr(func::Symbol, s::String)
 		r = ccall((func, _jellyfishlib), Ptr{Cchar}, (Ptr{Cchar},), s)
-		bytestring(r)
+		unsafe_string(r)
 	end
 
 	function soundex(s::String)
 		# _callstr(:soundex, s)
 		r = ccall((:soundex, _jellyfishlib), Ptr{Cchar}, (Ptr{Cchar},), s)
-		bytestring(r)
+		unsafe_string(r)
 	end
 
 	function metaphone(s::String)
 		# _callstr(:metaphone, s)
 		r = ccall((:metaphone, _jellyfishlib), Ptr{Cchar}, (Ptr{Cchar},), s)
-		bytestring(r)
+		unsafe_string(r)
 	end
 
 	function match_rating_codex(s::String)
 		# _callstr(:match_rating_codex, s)
 		r = ccall((:match_rating_codex, _jellyfishlib), Ptr{Cchar}, (Ptr{Cchar},), s)
-		bytestring(r)
+		unsafe_string(r)
 	end
 
 	function match_rating_comparison(s1::String, s2::String)
-		_calls1s2type(:match_rating_comparison, Bool, s1, s2)
+		@_calls1s2type(:match_rating_comparison, Bool, s1, s2)
 	end
 
 	function nysiis(s::String)
 		# _callstr(:nysiis, s)
 		r = ccall((:nysiis, _jellyfishlib), Ptr{Cchar}, (Ptr{Cchar},), s)
-		bytestring(r)
+		unsafe_string(r)
 	end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using JellyFish
-using Base.Test
+using Test
 
 jw = jaro_winkler("jellyfish", "smellyfish")
 jw_correct = 0.8962962962962964


### PR DESCRIPTION
This also drops all earlier Julia versions. The changes are pretty minor--mostly just the fact that `ccall` needs more information available at compile time, so I had to change one function into a macro. 